### PR TITLE
Don't start when -h is passed to zrpcd

### DIFF
--- a/zrpcd/zrpc_main.c
+++ b/zrpcd/zrpc_main.c
@@ -47,8 +47,7 @@ zrpc configuration across thrift defined model : vpnservice.\n\n\
 -P, --thrift_notif_port     Set thrift's notif update port number\n\
 -N, --thrift_notif_address  Set thrift's notif update specified address\n\
 -h, --help                  Display this help and exit\n\n");
-  if (status)
-    exit (status);
+  exit (status);
 }
 
 static void  zrpc_sigpipe (void)


### PR DESCRIPTION
-h has an exit code 0, so if(status) meant that exit was never called and zrpcd
 started, contrary to what is expected and printed.