### PR TITLE
make dist: Include all headers required for compilation

### DIFF
--- a/zrpcd/Makefile.am
+++ b/zrpcd/Makefile.am
@@ -18,6 +18,9 @@ libzrpc_a_SOURCES = \
 	qzmqclient.c qzcclient.capnp.c qzcclient.c zrpc_util.c \
 	zrpc_bgp_capnp.c
 
+pkginclude_HEADERS = \
+	zrpc_os_wrapper.h zrpc_global.h
+
 noinst_HEADERS = \
 	bgp_configurator.h bgp_updater.h vpnservice_types.h zrpc_bgp_updater.h \
 	zrpc_bgp_configurator.h zrpc_bgp_updater.h zrpc_debug.h zrpc_memory.h \


### PR DESCRIPTION
Some headers where missing from the archive resulting from 'make dist'.

Signed-off-by: Romanos Skiadas <rski@intracom-telecom.com>