### PR TITLE
Fix the warning with quagga package and rename zrpc package

### DIFF
--- a/pkgsrc/dev_compile_script.sh
+++ b/pkgsrc/dev_compile_script.sh
@@ -402,8 +402,9 @@ build_zrpcd (){
         LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$THRIFT_LIB_PATH:$ZRPCD_BUILD_FOLDER/zeromq4-1/.libs/:$ZRPCD_BUILD_FOLDER/c-capnproto/.libs/:$ZRPCD_BUILD_FOLDER/quagga/lib/.libs/ PATH=$PATH:$THRIFT_PATH make install DESTDIR=$INSTALL_DIR
         if [ -d .git ]; then
             COMMITID=`git log -n1 --format="%h"`
+            COMMITID=$COMMITID".thriftv"$THRIFT_VERSION
         else
-            COMMITID=""
+            COMMITID="thriftv"$THRIFT_VERSION
         fi
     fi
     # Temporarily disable this when using the dist method

--- a/pkgsrc/packaging.sh
+++ b/pkgsrc/packaging.sh
@@ -249,7 +249,7 @@ quagga_rpm_bin_spec () {
     echo "%pre" >> $RPM_SPEC_FILE
     echo "getent group quagga >/dev/null 2>&1 || groupadd -g 92 quagga >/dev/null 2>&1 || :" >> $RPM_SPEC_FILE
     echo "getent passwd quagga >/dev/null 2>&1 || useradd -u 92 -g 92 -M -r -s /sbin/nologin \\" >> $RPM_SPEC_FILE
-    echo " -c "Quagga routing suite" -d /var/run/quagga quagga >/dev/null 2>&1 || :" >> $RPM_SPEC_FILE
+    echo " -d /var/run/quagga quagga >/dev/null 2>&1 || :" >> $RPM_SPEC_FILE
     echo >> $RPM_SPEC_FILE
 
     echo "%postun" >> $RPM_SPEC_FILE


### PR DESCRIPTION
Hi @pguibert6WIND @maheshloni ,

I made two patches, please review.
1. pkgsrc: quagga packaging was not creating user quagga
    It fixes the warning when quagga package is installed on CentOS
     -"warning: user quagga does not exist - using root" 
2. pkgsrc: add thrift version into zrpc package name
    For example:
           zrpc_0.2.fbebf125aa74.thriftv5.Ubuntu14.04_amd64.deb
           zrpc-0.2.fbebf12.thriftv5.CentOS7.3.1611-0.x86_64.rpm