### PR TITLE
ODL connection is closed after disableMultipath()

### DIFF
--- a/zrpcd/zrpc_bgp_configurator.c
+++ b/zrpcd/zrpc_bgp_configurator.c
@@ -3602,6 +3602,7 @@ zrpc_bgp_set_multipath(struct zrpc_vpnservice *ctxt,  gint32* _return, const af_
             zrpc_info ("disableMultipath config for afi:%d safi:%d NOK",
                        afi, safi);
         }
+      return FALSE;
     }
   if (zrpc_vpnservice_get_bgp_context(ctxt)->asNumber == 0)
     {


### PR DESCRIPTION
This patch fixes the commit 46d1183a0c37("zrpcd: two fixes on
enableMultipath/disableMultipath handler").

For enableMultipath/disableMultipath handler, True will be returned
with an assigned error in two cases:
- when multipath is already disabled, disableMultipath() is called
- when multipath is already enabled, enableMltipath() is called

In both cases, zrpcd will disconnect peer ODL.

Signed-off-by: Xiaofeng Liu <xiaofeng.liu@6wind.com>